### PR TITLE
집 찾기 화면 바텀 시트 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.9.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.recyclerview:recyclerview:1.3.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/ssafy/tott/domain/model/SimpleHouse.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/model/SimpleHouse.kt
@@ -1,0 +1,3 @@
+package com.ssafy.tott.domain.model
+
+data class SimpleHouse(val lat: Double, val lng: Double)

--- a/app/src/main/java/com/ssafy/tott/ui/houselist/SimpleHouseListAdapter.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/houselist/SimpleHouseListAdapter.kt
@@ -1,0 +1,42 @@
+package com.ssafy.tott.ui.houselist
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.ssafy.tott.databinding.ItemSimpleHouseBinding
+import com.ssafy.tott.domain.model.SimpleHouse
+
+class SimpleHouseListAdapter : ListAdapter<SimpleHouse, RecyclerView.ViewHolder>(diffUtil) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val binding = ItemSimpleHouseBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        val holder = SimpleHouseViewHolder(binding)
+        binding.root.setOnClickListener {
+            Log.d("SimpleHouseListAdapter", it.toString())
+            // TODO 리스트 클릭
+        }
+        return holder
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is SimpleHouseViewHolder -> holder.bind(getItem(position))
+        }
+    }
+
+    companion object {
+        private val diffUtil = object : DiffUtil.ItemCallback<SimpleHouse>() {
+            override fun areItemsTheSame(oldItem: SimpleHouse, newItem: SimpleHouse): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: SimpleHouse, newItem: SimpleHouse): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/ui/houselist/SimpleHouseViewHolder.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/houselist/SimpleHouseViewHolder.kt
@@ -1,0 +1,12 @@
+package com.ssafy.tott.ui.houselist
+
+import androidx.recyclerview.widget.RecyclerView
+import com.ssafy.tott.databinding.ItemSimpleHouseBinding
+import com.ssafy.tott.domain.model.SimpleHouse
+
+class SimpleHouseViewHolder(private val binding: ItemSimpleHouseBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+    fun bind(item: SimpleHouse) {
+        binding.tvSimpleHouseItem.text = item.toString()
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/ui/map/SearchMapActivity.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/map/SearchMapActivity.kt
@@ -22,6 +22,7 @@ class SearchMapActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private lateinit var map: GoogleMap
     private lateinit var binding: ActivitySearchMapBinding
+    private val modalBottomSheet = SimpleHouseListDialogFragment()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,6 +32,8 @@ class SearchMapActivity : AppCompatActivity(), OnMapReadyCallback {
         val mapFragment = supportFragmentManager
             .findFragmentById(R.id.fragmentContainer_searchMap) as SupportMapFragment
         mapFragment.getMapAsync(this)
+
+        modalBottomSheet.show(supportFragmentManager, SimpleHouseListDialogFragment.TAG)
     }
 
     override fun onMapReady(googleMap: GoogleMap) {

--- a/app/src/main/java/com/ssafy/tott/ui/map/SimpleHouseListDialogFragment.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/map/SimpleHouseListDialogFragment.kt
@@ -1,0 +1,55 @@
+package com.ssafy.tott.ui.map
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.ssafy.tott.databinding.RvSimpleHouseBinding
+import com.ssafy.tott.domain.model.SimpleHouse
+import com.ssafy.tott.ui.houselist.SimpleHouseListAdapter
+
+const val ARG_ITEM_COUNT = "item_count"
+
+class SimpleHouseListDialogFragment : BottomSheetDialogFragment() {
+
+    private var _binding: RvSimpleHouseBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = RvSimpleHouseBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        initRecycleView()
+    }
+
+    private fun initRecycleView() {
+        val adapter = SimpleHouseListAdapter()
+        //TODO 임시 데이터
+        adapter.submitList(listOf(SimpleHouse(0.0, 0.1), SimpleHouse(123.0, 2.3)))
+        binding.rvSimpleHouse.layoutManager = LinearLayoutManager(context)
+        binding.rvSimpleHouse.adapter = adapter
+    }
+
+    companion object {
+        fun newInstance(itemCount: Int): SimpleHouseListDialogFragment =
+            SimpleHouseListDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putInt(ARG_ITEM_COUNT, itemCount)
+                }
+            }
+
+        const val TAG = "ModalBottomSheet"
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/activity_search_map.xml
+++ b/app/src/main/res/layout/activity_search_map.xml
@@ -1,49 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/background">
+    android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar_searchMap"
-        style="@style/TOTT.Toolbar"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        app:layout_constraintBottom_toTopOf="@id/chipGroup_searchMap"
-        app:layout_constraintTop_toTopOf="parent"
-        app:menu="@menu/menu_search_map"
-        app:title="집 검색" />
+        android:layout_height="match_parent"
+        android:background="@color/background"
+        tools:context=".ui.map.SearchMapActivity">
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/darkGray"
-        app:layout_constraintTop_toBottomOf="@id/toolbar_searchMap" />
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_searchMap"
+            style="@style/TOTT.Toolbar"
+            android:layout_width="match_parent"
+            app:layout_constraintBottom_toTopOf="@id/chipGroup_searchMap"
+            app:layout_constraintTop_toTopOf="parent"
+            app:menu="@menu/menu_search_map"
+            app:title="집 검색" />
 
-    <com.google.android.material.chip.ChipGroup
-        android:id="@+id/chipGroup_searchMap"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="4dp"
-        app:layout_constraintBottom_toTopOf="@id/fragmentContainer_searchMap"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar_searchMap">
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/darkGray"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_searchMap" />
 
-        <com.google.android.material.chip.Chip
-            android:layout_width="wrap_content"
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/chipGroup_searchMap"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="chip" />
-    </com.google.android.material.chip.ChipGroup>
+            android:layout_marginStart="4dp"
+            app:layout_constraintBottom_toTopOf="@id/fragmentContainer_searchMap"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_searchMap">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragmentContainer_searchMap"
-        android:name="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/chipGroup_searchMap"
-        tools:context=".ui.map.SearchMapActivity"
-        tools:layout="@layout/fragment_dummy" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.chip.Chip
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="chip" />
+        </com.google.android.material.chip.ChipGroup>
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragmentContainer_searchMap"
+            android:name="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/chipGroup_searchMap"
+            tools:context=".ui.map.SearchMapActivity"
+            tools:layout="@layout/fragment_dummy" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+<!--    <com.google.android.material.circularreveal.CircularRevealFrameLayout-->
+<!--        android:id="@+id/standard_bottom_sheet"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">-->
+
+<!--        <com.google.android.material.textview.MaterialTextView-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="match_parent"-->
+<!--            android:text="bottom sheet" />-->
+<!--    </com.google.android.material.circularreveal.CircularRevealFrameLayout>-->
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_search_map.xml
+++ b/app/src/main/res/layout/activity_search_map.xml
@@ -1,67 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/background"
+    tools:context=".ui.map.SearchMapActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_searchMap"
+        style="@style/TOTT.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/background"
-        tools:context=".ui.map.SearchMapActivity">
+        app:layout_constraintBottom_toTopOf="@id/chipGroup_searchMap"
+        app:layout_constraintTop_toTopOf="parent"
+        app:menu="@menu/menu_search_map"
+        app:title="집 검색" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar_searchMap"
-            style="@style/TOTT.Toolbar"
-            android:layout_width="match_parent"
-            app:layout_constraintBottom_toTopOf="@id/chipGroup_searchMap"
-            app:layout_constraintTop_toTopOf="parent"
-            app:menu="@menu/menu_search_map"
-            app:title="집 검색" />
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/darkGray"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_searchMap" />
 
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/darkGray"
-            app:layout_constraintTop_toBottomOf="@id/toolbar_searchMap" />
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/chipGroup_searchMap"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        app:layout_constraintBottom_toTopOf="@id/fragmentContainer_searchMap"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_searchMap">
 
-        <com.google.android.material.chip.ChipGroup
-            android:id="@+id/chipGroup_searchMap"
-            android:layout_width="0dp"
+        <com.google.android.material.chip.Chip
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
-            app:layout_constraintBottom_toTopOf="@id/fragmentContainer_searchMap"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar_searchMap">
+            android:text="chip" />
+    </com.google.android.material.chip.ChipGroup>
 
-            <com.google.android.material.chip.Chip
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="chip" />
-        </com.google.android.material.chip.ChipGroup>
-
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/fragmentContainer_searchMap"
-            android:name="com.google.android.gms.maps.SupportMapFragment"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/chipGroup_searchMap"
-            tools:context=".ui.map.SearchMapActivity"
-            tools:layout="@layout/fragment_dummy" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-<!--    <com.google.android.material.circularreveal.CircularRevealFrameLayout-->
-<!--        android:id="@+id/standard_bottom_sheet"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">-->
-
-<!--        <com.google.android.material.textview.MaterialTextView-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="match_parent"-->
-<!--            android:text="bottom sheet" />-->
-<!--    </com.google.android.material.circularreveal.CircularRevealFrameLayout>-->
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentContainer_searchMap"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/chipGroup_searchMap"
+        tools:context=".ui.map.SearchMapActivity"
+        tools:layout="@layout/fragment_dummy" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_simple_house.xml
+++ b/app/src/main/res/layout/item_simple_house.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tv_simpleHouse_item"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:text="Hello" />

--- a/app/src/main/res/layout/rv_simple_house.xml
+++ b/app/src/main/res/layout/rv_simple_house.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rv_simpleHouse"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:paddingTop="30dp"
+    tools:context=".ui.map.SimpleHouseListDialogFragment"
+    tools:listitem="@layout/item_simple_house" />


### PR DESCRIPTION
# 개요

- 집 찾기 화면에 집 목록을 보여줄 바텀 시트 추가

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
<!-- example ) -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 한 일

- BottomSheet 추가
  - BottomSheetDialogFragment 사용
- 간단한 집 정보를 보여줄 RecyclerView 구현
  - 아직 문자열로 출력하는 목록
    - 레이아웃 구현 필요
  - 찜 목록, 최근 본 집 목록에서 사용 가능 할 것으로 보임
  

<!-- 한 일 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

## ETC

<img src="https://github.com/SSAFY-TOTT/Android/assets/60271512/ddf23973-34bd-4b0c-839e-8bed07594765" width="30%">

- 참고 링크
  - https://myung6024.tistory.com/171
  - https://www.notion.so/BottomSheetDialogFragment-4c20520768c84e92a14ddeec54004825



<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->



Resolve #6