### PR TITLE
지도에 사용할 마커 클래스 데이터 변경

### DIFF
--- a/app/src/main/java/com/ssafy/tott/domain/model/Building.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/model/Building.kt
@@ -1,0 +1,15 @@
+package com.ssafy.tott.domain.model
+
+import com.google.android.gms.maps.model.LatLng
+
+data class Building(
+    val lat: Double,
+    val lng: Double,
+    val buildingDetails: List<BuildingDetail>,
+    val legalDongName: String,
+    val districtName: String,
+    val buildingName: String,
+) {
+    val latLng = LatLng(lat, lng)
+    val simpleAddress = "$districtName $legalDongName $buildingName"
+}

--- a/app/src/main/java/com/ssafy/tott/domain/model/BuildingDetail.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/model/BuildingDetail.kt
@@ -1,6 +1,6 @@
 package com.ssafy.tott.domain.model
 
-data class House(
+data class BuildingDetail(
     val id: Int,
     val price: Int, // 가격 단위: 백만원
     val area: Int, // 면적 단위: 평

--- a/app/src/main/java/com/ssafy/tott/domain/model/House.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/model/House.kt
@@ -1,6 +1,8 @@
 package com.ssafy.tott.domain.model
 
 data class House(
-    val lat: Double,
-    val lng: Double,
+    val id: Int,
+    val price: Int, // 가격 단위: 백만원
+    val area: Int, // 면적 단위: 평
+    val floor: Int?,
 )

--- a/app/src/main/java/com/ssafy/tott/ui/model/ClusterMarker.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/model/ClusterMarker.kt
@@ -2,33 +2,19 @@ package com.ssafy.tott.ui.model
 
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.clustering.ClusterItem
-import com.ssafy.tott.domain.model.House
+import com.ssafy.tott.domain.model.Building
+import com.ssafy.tott.domain.model.BuildingDetail
 
 data class ClusterMarker(
-    val lat: Double,
-    val lng: Double,
-    private val markerSnippet: String?,
-    private val markerTitle: String?,
+    val building: Building,
+    val buildingDetails: List<BuildingDetail>,
+    private val markerSnippet: String? = building.simpleAddress,
+    private val markerTitle: String? = building.buildingName,
 ) : ClusterItem {
-    constructor(
-        latLng: LatLng, snippet: String?, title: String?
-    ) : this(latLng.latitude, latLng.longitude, snippet, title)
+    private val simpleAddress get() = building.simpleAddress
 
-    private val latLng get() = LatLng(lat, lng)
-    override fun getPosition(): LatLng = latLng
+    override fun getPosition(): LatLng = building.latLng
     override fun getSnippet(): String? = markerSnippet
-    override fun getZIndex(): Float? {
-        return null
-    }
-
+    override fun getZIndex(): Float? = null
     override fun getTitle(): String? = markerTitle
-
-    companion object {
-        fun House.toClusterMarker(): ClusterMarker = ClusterMarker(
-            lat = this.lat,
-            lng = this.lng,
-            markerSnippet = "snippet",
-            markerTitle = toString(),
-        )
-    }
 }


### PR DESCRIPTION
# 개요

- 지도에서 사용하는 클러스터링 마커 클래스 데이터 변경

resolve #5

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
<!-- example ) -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 한 일

건물 데이터

- 위도, 경도 좌표
- 자치구, 법정동
- 건물명
- 건물의 매물 목록

매물 데이터
- 아이디
- 가격(단위: 백만)
- 면적(단위: 평)
- 층(없을 수 있음)

클러스터 데이터 변경
- 건물 데이터 클래스를 갖도록 변경
- 좌표를 건물에서 가져오도록 변경
- 타이틀과 스니펫의 기본 값을 건물명, 주소로 변경

<!-- 한 일 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

## ETC

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->