### PR TITLE
매물 상세 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 
     id("com.google.dagger.hilt.android")
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
+
+    id("kotlin-parcelize")
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,13 +13,17 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.TOTT"
         tools:targetApi="31">
-        <activity
-            android:name=".ui.searchfilter.SearchFilterActivity"
-            android:exported="false" />
-
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${MAP_API_KEY}" />
+
+        <activity
+            android:name=".ui.buildingdetail.BuildingDetailActivity"
+            android:exported="false" />
+
+        <activity
+            android:name=".ui.searchfilter.SearchFilterActivity"
+            android:exported="false" />
 
         <activity
             android:name=".ui.map.SearchMapActivity"

--- a/app/src/main/java/com/ssafy/tott/ui/buildingdetail/BuildingDetailActivity.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/buildingdetail/BuildingDetailActivity.kt
@@ -1,0 +1,83 @@
+package com.ssafy.tott.ui.buildingdetail
+
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.ktx.addMarker
+import com.ssafy.tott.R
+import com.ssafy.tott.databinding.ActivityBuildingDetailBinding
+import com.ssafy.tott.ui.model.BuildingDetailUI
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BuildingDetailActivity : AppCompatActivity(), OnMapReadyCallback {
+    private lateinit var map: GoogleMap
+    private lateinit var binding: ActivityBuildingDetailBinding
+    private var buildingDetailUI: BuildingDetailUI? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityBuildingDetailBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        buildingDetailUI = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(TAG_BUILDING_DETAIL, BuildingDetailUI::class.java)
+        } else {
+            intent.getParcelableExtra(TAG_BUILDING_DETAIL)
+        }
+        initLayout()
+        initMap()
+    }
+
+    private fun initLayout() {
+        buildingDetailUI?.run {
+            binding.tvAddressBuildingDetail.text = simpleAddress
+            binding.tvAreaBuildingDetail.text = getString(R.string.area_buildingDetail_item, area)
+            binding.tvPriceBuildingDetail.text =
+                getString(R.string.price_buildingDetail_item, price)
+            if (floor == null) {
+                binding.tvFloorBuildingDetail.visibility = View.INVISIBLE
+            } else {
+                binding.tvFloorBuildingDetail.text =
+                    getString(R.string.floor_buildingDetail_item, floor)
+            }
+            binding.tvBuiltBuildingDetail.text =
+                getString(R.string.built_buildingDetail_item, built)
+        }
+    }
+
+    private fun initMap() {
+        MapsInitializer.initialize(this)
+        val mapFragment = supportFragmentManager
+            .findFragmentById(R.id.map_buildingDetail) as SupportMapFragment
+        mapFragment.getMapAsync(this)
+
+    }
+
+    override fun onMapReady(googleMap: GoogleMap) {
+        Log.d("BuildingDetailActivity", "onMapReady: start")
+        map = googleMap
+        map.uiSettings.isMapToolbarEnabled = false
+        map.setOnMapClickListener { }
+        buildingDetailUI?.run {
+            Log.d("BuildingDetailActivity", "onMapReady: $buildingDetailUI")
+            val latLng = LatLng(lat, lng)
+            map.moveCamera(CameraUpdateFactory.newLatLng(latLng))
+            map.addMarker {
+                position(latLng)
+                title(simpleAddress)
+            }
+        }
+    }
+
+    companion object {
+        const val TAG_BUILDING_DETAIL = "TAG_BUILDING_DETAIL"
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/ui/model/BuildingDetailUI.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/model/BuildingDetailUI.kt
@@ -1,5 +1,9 @@
 package com.ssafy.tott.ui.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 // UI에 사용할 매물 데이터
 data class BuildingDetailUI(
     val id: Int,
@@ -9,4 +13,5 @@ data class BuildingDetailUI(
     val lat: Double,
     val lng: Double,
     val simpleAddress: String,
-)
+    val built: Int,
+) : Parcelable

--- a/app/src/main/res/drawable/ic_favorite.xml
+++ b/app/src/main/res/drawable/ic_favorite.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M480,840L422,788Q321,697 255,631Q189,565 150,512.5Q111,460 95.5,416Q80,372 80,326Q80,232 143,169Q206,106 300,106Q352,106 399,128Q446,150 480,190Q514,150 561,128Q608,106 660,106Q754,106 817,169Q880,232 880,326Q880,372 864.5,416Q849,460 810,512.5Q771,565 705,631Q639,697 538,788L480,840Z" />
+</vector>

--- a/app/src/main/res/layout/activity_building_detail.xml
+++ b/app/src/main/res/layout/activity_building_detail.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:map="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/DefaultConstraint"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.buildingdetail.BuildingDetailActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_buildingDetail"
+        style="@style/TOTT.Toolbar"
+        android:layout_width="match_parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:menu="@menu/menu_building_detail"
+        app:title="@string/toolbar_buildingDetail_item" />
+
+    <!--  TODO 임시로 main logo 이미지 수정 지정  -->
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/iv_room_buildingDetail"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:src="@drawable/main_logo"
+        app:layout_constraintDimensionRatio="5:3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_buildingDetail"
+        app:layout_constraintWidth_percent="0.7" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guildLine_start_buildingDetail"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.1" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tv_address_buildingDetail"
+        style="@style/TextAppearance.MaterialComponents.Headline5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        app:layout_constraintBottom_toTopOf="@id/tv_price_buildingDetail"
+        app:layout_constraintStart_toStartOf="@id/guildLine_start_buildingDetail"
+        app:layout_constraintTop_toBottomOf="@id/iv_room_buildingDetail"
+        tools:text="강남구 역삼1동 멀티 캠퍼스" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tv_price_buildingDetail"
+        style="@style/TextAppearance.MaterialComponents.Headline4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/tv_area_buildingDetail"
+        app:layout_constraintStart_toStartOf="@id/guildLine_start_buildingDetail"
+        app:layout_constraintTop_toBottomOf="@+id/tv_address_buildingDetail"
+        tools:text="5800만원" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tv_area_buildingDetail"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/tv_floor_buildingDetail"
+        app:layout_constraintStart_toStartOf="@id/guildLine_start_buildingDetail"
+        app:layout_constraintTop_toBottomOf="@+id/tv_price_buildingDetail"
+        tools:text="35평" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tv_floor_buildingDetail"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/tv_built_buildingDetail"
+        app:layout_constraintStart_toStartOf="@id/guildLine_start_buildingDetail"
+        app:layout_constraintTop_toBottomOf="@+id/tv_area_buildingDetail"
+        tools:text="16층" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tv_built_buildingDetail"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/map_buildingDetail"
+        app:layout_constraintStart_toStartOf="@id/guildLine_start_buildingDetail"
+        app:layout_constraintTop_toBottomOf="@+id/tv_floor_buildingDetail"
+        tools:text="18년 건축" />
+
+    <fragment
+        android:id="@+id/map_buildingDetail"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="5:3"
+        map:cameraZoom="16"
+        map:liteMode="true"
+        tools:layout="@layout/fragment_dummy" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_building_detail.xml
+++ b/app/src/main/res/menu/menu_building_detail.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_favorite"
+        android:icon="@drawable/ic_favorite"
+        android:title="@string/toolbar_buildingDetail_item"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">TOTT</string>
 
-<!--    필터 설정 화면  -->
+    <!--    필터 설정 화면  -->
     <string name="toolbar_set_filter">필터 설정</string>
     <string name="apartment_btn_search_filter">아파트</string>
     <string name="officetel_btn_search_filter">오피스텔</string>
@@ -12,8 +12,11 @@
     <string name="houseType_searchFilter">종류</string>
     <string name="toolbar_saveFilter">저장</string>
 
-    <!--  매물 목록 화면  -->
+    <!--  매물 화면  -->
+    <string name="toolbar_buildingDetail_item">상세 정보</string>
     <string name="area_buildingDetail_item">%1$d평</string>
     <string name="address_buildingDetail_item">%1$s</string>
     <string name="price_buildingDetail_item">%1$,d만원</string>
+    <string name="built_buildingDetail_item">%1$d년 건축</string>
+    <string name="floor_buildingDetail_item">%1$d층</string>
 </resources>


### PR DESCRIPTION
# 개요

- 매물의 상세 정보를 보여주는 화면 구현

resolve #10 

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
<!-- example ) -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 한 일

- 상세 정보 레이아웃 구성
  - 방 사진
    - 메인 로고를 임시로 지정
  - 주소, 건물명, 가격, 면적, 층, 건축 년도
  - 지도에 위치 표시
- 화면 표시용 클래스에 직렬화 기능 추가
  - 직렬화 플러그인 추가
- 텍스트 포맷 추가
  - 층, 건축년도 표시
- 찜 아이콘 추가

<!-- 한 일 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

## ETC

<img src="https://github.com/SSAFY-TOTT/Android/assets/60271512/fc70fdef-d8c6-424a-b8ab-0819092632d9" width="40%">

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->