### PR TITLE
매물 검색을 실제 서버에서 가져오도록 변경

### DIFF
--- a/app/src/main/java/com/ssafy/tott/data/datasource/BuildingDataSource.kt
+++ b/app/src/main/java/com/ssafy/tott/data/datasource/BuildingDataSource.kt
@@ -1,9 +1,9 @@
 package com.ssafy.tott.data.datasource
 
-import com.ssafy.tott.domain.model.Building
-import com.ssafy.tott.domain.model.SearchFilter
+import com.ssafy.tott.data.model.request.SearchFilterRequest
+import com.ssafy.tott.data.model.response.BuildingListResponse
 import kotlinx.coroutines.flow.Flow
 
 interface BuildingDataSource {
-    fun searchBuilding(searchFilter: SearchFilter): Flow<List<Building>>
+    fun searchBuilding(searchFilter: SearchFilterRequest): Flow<Result<BuildingListResponse>>
 }

--- a/app/src/main/java/com/ssafy/tott/data/datasource/remote/BuildingRemoteDataSource.kt
+++ b/app/src/main/java/com/ssafy/tott/data/datasource/remote/BuildingRemoteDataSource.kt
@@ -1,19 +1,38 @@
 package com.ssafy.tott.data.datasource.remote
 
+import android.util.Log
 import com.ssafy.tott.data.datasource.BuildingDataSource
-import com.ssafy.tott.domain.model.Building
-import com.ssafy.tott.domain.model.BuildingDetail
-import com.ssafy.tott.domain.model.SearchFilter
+import com.ssafy.tott.data.model.request.SearchFilterRequest
+import com.ssafy.tott.data.model.response.BuildingListResponse
+import com.ssafy.tott.di.SearchBuildingService
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
 
-class BuildingRemoteDataSource : BuildingDataSource {
-    override fun searchBuilding(searchFilter: SearchFilter): Flow<List<Building>> = flow {
-        // TODO: 임시 데이터
-        val list = listOf<Building>(
-            Building(37.5152464, 127.0428016, listOf(BuildingDetail(234, 122, 18, 2)), "동", "구", "건물"),
-            Building(37.5052464, 127.0498016, listOf(BuildingDetail(0, 1, 3, null)), "동", "구", "건물")
-        )
-        emit(list)
-    }
+class BuildingRemoteDataSource @Inject constructor(private val buildingService: SearchBuildingService) :
+    BuildingDataSource {
+    override fun searchBuilding(searchFilter: SearchFilterRequest): Flow<Result<BuildingListResponse>> =
+        flow {
+            val response = searchFilter.run {
+                buildingService.fetchSearchedBuilding(
+                    districtName = districtName,
+                    legalDongName = legalDongName,
+                    minPrice = minPrice,
+                    maxPrice = maxPrice,
+                    minArea = minArea,
+                    maxArea = maxArea,
+                    types = types,
+                    built = built
+                )
+            }
+            if (response.isSuccessful) {
+                val data = response.body() ?: BuildingListResponse(listOf())
+                Log.d("BuildingRemoteDataSource", "searchBuilding suspendOnSuccess: $data")
+                emit(Result.success(data))
+            } else {
+                emit(Result.failure(Throwable("연결에 실패했습니다.")))
+            }
+        }.flowOn(Dispatchers.IO)
 }

--- a/app/src/main/java/com/ssafy/tott/data/model/request/SearchFilterRequest.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/request/SearchFilterRequest.kt
@@ -1,0 +1,27 @@
+package com.ssafy.tott.data.model.request
+
+import com.ssafy.tott.domain.model.SearchFilter
+
+data class SearchFilterRequest(
+    val districtName: String,
+    val legalDongName: String,
+    val minPrice: Int,
+    val maxPrice: Int,
+    val minArea: Int,
+    val maxArea: Int,
+    val types: List<String>,
+    val built: Int,
+) {
+    companion object {
+        fun SearchFilter.toData() = SearchFilterRequest(
+            districtName = districtName,
+            legalDongName = legalDongName,
+            minPrice = minPrice,
+            maxPrice = maxPrice,
+            minArea = minArea,
+            maxArea = maxArea,
+            types = type,
+            built = built
+        )
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/data/model/response/BuildingDetailResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/BuildingDetailResponse.kt
@@ -1,11 +1,16 @@
 package com.ssafy.tott.data.model.response
 
+import com.google.gson.annotations.SerializedName
 import com.ssafy.tott.domain.model.BuildingDetail
 
 data class BuildingDetailResponse(
+    @SerializedName("id")
     val id: Int,
+    @SerializedName("price")
     val price: Int, // 가격 단위: 천만원
+    @SerializedName("area")
     val area: Int, // 면적 단위: 평
+    @SerializedName("floor")
     val floor: Int?,
 ) {
     fun toDomain() = BuildingDetail(

--- a/app/src/main/java/com/ssafy/tott/data/model/response/BuildingDetailResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/BuildingDetailResponse.kt
@@ -1,0 +1,17 @@
+package com.ssafy.tott.data.model.response
+
+import com.ssafy.tott.domain.model.BuildingDetail
+
+data class BuildingDetailResponse(
+    val id: Int,
+    val price: Int, // 가격 단위: 천만원
+    val area: Int, // 면적 단위: 평
+    val floor: Int?,
+) {
+    fun toDomain() = BuildingDetail(
+        id = id,
+        price = price,
+        area = area,
+        floor = floor,
+    )
+}

--- a/app/src/main/java/com/ssafy/tott/data/model/response/BuildingListResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/BuildingListResponse.kt
@@ -1,0 +1,8 @@
+package com.ssafy.tott.data.model.response
+
+import com.google.gson.annotations.SerializedName
+
+data class BuildingListResponse(
+    @SerializedName("response")
+    val buildingListResponse: List<BuildingResponse>
+)

--- a/app/src/main/java/com/ssafy/tott/data/model/response/BuildingResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/BuildingResponse.kt
@@ -1,0 +1,31 @@
+package com.ssafy.tott.data.model.response
+
+import com.google.gson.annotations.SerializedName
+import com.ssafy.tott.domain.model.Building
+
+data class BuildingResponse(
+    @SerializedName("lat")
+    val lat: Double,
+    @SerializedName("lng")
+    val lng: Double,
+    @SerializedName("buildingDetails")
+    val buildingDetails: List<BuildingDetailResponse>,
+    @SerializedName("legalDongName")
+    val legalDongName: String,
+    @SerializedName("districtName")
+    val districtName: String,
+    @SerializedName("buildingName")
+    val buildingName: String,
+    @SerializedName("built")
+    val built: Int,
+) {
+    fun toDomain() = Building(
+        districtName = districtName,
+        legalDongName = legalDongName,
+        buildingDetails = buildingDetails.map(BuildingDetailResponse::toDomain),
+        buildingName = "$districtName $legalDongName $buildingName",
+        lat = lat,
+        lng = lng,
+        built = built,
+    )
+}

--- a/app/src/main/java/com/ssafy/tott/data/repository/BuildingRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/tott/data/repository/BuildingRepositoryImpl.kt
@@ -1,14 +1,18 @@
 package com.ssafy.tott.data.repository
 
 import com.ssafy.tott.data.datasource.BuildingDataSource
+import com.ssafy.tott.data.model.request.SearchFilterRequest.Companion.toData
 import com.ssafy.tott.domain.model.Building
 import com.ssafy.tott.domain.model.SearchFilter
 import com.ssafy.tott.domain.repository.SearchBuildingRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class BuildingRepositoryImpl(private val buildingDataSource: BuildingDataSource) :
     SearchBuildingRepository {
-    override fun getBuildings(searchFilter: SearchFilter): Flow<List<Building>> {
-        return buildingDataSource.searchBuilding(searchFilter)
+    override fun getBuildings(searchFilter: SearchFilter): Flow<Result<List<Building>>> {
+        return buildingDataSource.searchBuilding(searchFilter.toData()).map { result ->
+            result.map { response -> response.buildingListResponse.map { it.toDomain() } }
+        }
     }
 }

--- a/app/src/main/java/com/ssafy/tott/di/ApiService.kt
+++ b/app/src/main/java/com/ssafy/tott/di/ApiService.kt
@@ -8,7 +8,7 @@ import retrofit2.http.Query
 
 interface SearchBuildingService {
     @FormUrlEncoded
-    @GET("/api/auth/region/search")
+    @GET("/api/house/search")
     suspend fun fetchSearchedBuilding(
         @Query("districtName")
         districtName: String,

--- a/app/src/main/java/com/ssafy/tott/di/ApiService.kt
+++ b/app/src/main/java/com/ssafy/tott/di/ApiService.kt
@@ -1,0 +1,30 @@
+package com.ssafy.tott.di
+
+import com.ssafy.tott.data.model.response.BuildingListResponse
+import retrofit2.Response
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface SearchBuildingService {
+    @FormUrlEncoded
+    @GET("/api/auth/region/search")
+    suspend fun fetchSearchedBuilding(
+        @Query("districtName")
+        districtName: String,
+        @Query("legalDongName")
+        legalDongName: String,
+        @Query("minPrice")
+        minPrice: Int,
+        @Query("maxPrice")
+        maxPrice: Int,
+        @Query("minArea")
+        minArea: Int,
+        @Query("maxArea")
+        maxArea: Int,
+        @Query("types")
+        types: List<String>,
+        @Query("built")
+        built: Int,
+    ): Response<BuildingListResponse>
+}

--- a/app/src/main/java/com/ssafy/tott/di/DataModule.kt
+++ b/app/src/main/java/com/ssafy/tott/di/DataModule.kt
@@ -20,6 +20,6 @@ object DataModule {
 
     @Provides
     @Singleton
-    fun provideSearchBuildingDataSource(): BuildingDataSource =
-        BuildingRemoteDataSource()
+    fun provideSearchBuildingDataSource(buildingService: SearchBuildingService): BuildingDataSource =
+        BuildingRemoteDataSource(buildingService)
 }

--- a/app/src/main/java/com/ssafy/tott/di/NetworkModule.kt
+++ b/app/src/main/java/com/ssafy/tott/di/NetworkModule.kt
@@ -1,0 +1,50 @@
+package com.ssafy.tott.di
+
+import com.google.maps.android.v3.ktx.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    private const val BASE_URL = "https://www.google.com/"
+
+    @Provides
+    fun provideBaseUrl() = BASE_URL
+
+    @Singleton
+    @Provides
+    fun provideOkHttpClient() = if (BuildConfig.DEBUG) {
+        OkHttpClient.Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor()
+                    .setLevel(HttpLoggingInterceptor.Level.BODY)
+            )
+            .build()
+    } else {
+        OkHttpClient.Builder().build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .client(okHttpClient)
+            .baseUrl(provideBaseUrl())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideApiService(retrofit: Retrofit): SearchBuildingService {
+        return retrofit.create(SearchBuildingService::class.java)
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/domain/model/Building.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/model/Building.kt
@@ -10,6 +10,7 @@ data class Building(
     val legalDongName: String,
     val districtName: String,
     val buildingName: String,
+    val built: Int,
 ) {
     val latLng = LatLng(lat, lng)
     val simpleAddress = "$districtName $legalDongName $buildingName"

--- a/app/src/main/java/com/ssafy/tott/domain/model/BuildingDetail.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/model/BuildingDetail.kt
@@ -3,7 +3,7 @@ package com.ssafy.tott.domain.model
 //매물
 data class BuildingDetail(
     val id: Int,
-    val price: Int, // 가격 단위: 백만원
+    val price: Int, // 가격 단위: 천만원
     val area: Int, // 면적 단위: 평
     val floor: Int?,
 )

--- a/app/src/main/java/com/ssafy/tott/domain/repository/SearchBuildingRepository.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/repository/SearchBuildingRepository.kt
@@ -6,5 +6,5 @@ import kotlinx.coroutines.flow.Flow
 
 
 interface SearchBuildingRepository {
-    fun getBuildings(searchFilter: SearchFilter): Flow<List<Building>>
+    fun getBuildings(searchFilter: SearchFilter): Flow<Result<List<Building>>>
 }

--- a/app/src/main/java/com/ssafy/tott/domain/usecase/SearchBuildingUseCase.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/usecase/SearchBuildingUseCase.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class SearchBuildingUseCase @Inject constructor(private val buildingRepository: SearchBuildingRepository) {
-    operator fun invoke(searchFilter: SearchFilter): Flow<List<Building>> {
+    operator fun invoke(searchFilter: SearchFilter): Flow<Result<List<Building>>> {
         return buildingRepository.getBuildings(searchFilter)
     }
 }

--- a/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
@@ -79,9 +79,13 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
             type, built
         )
         viewModelScope.launch {
-            useCase(searchFilter).collect {
-                Log.d(this::class.simpleName, "loadFilteredData: $it")
-                _buildings.value = it
+            useCase(searchFilter).collect { result ->
+                Log.d(this::class.simpleName, "loadFilteredData: $result")
+                result.onSuccess {
+                    _buildings.value = result.getOrThrow()
+                }.onFailure {
+                    Log.d(this::class.simpleName, "loadFilteredData: ${it.message}")
+                }
             }
         }
     }


### PR DESCRIPTION
# 개요

- 매물 데이터를 가져올 때 실제 데이터를 가져오도록 변경

resolve #24

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
<!-- example ) -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 한 일

- DataSource 구현
- Repository 매핑 및 반환 타입 변경
- API 모듈 추가
- 도메일 모델 클래스 변경
- ViewModel에서 요청 결과에 따라 값 반영

<!-- 한 일 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

## ETC

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->