### PR TITLE
집 찾기 필터링 값 변경 & 스타일 수정

### DIFF
--- a/app/src/main/java/com/ssafy/tott/ui/map/SearchMapActivity.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/map/SearchMapActivity.kt
@@ -42,7 +42,9 @@ class SearchMapActivity : AppCompatActivity(), OnMapReadyCallback {
             .findFragmentById(R.id.fragmentContainer_map_searchMap) as SupportMapFragment
         mapFragment.getMapAsync(this)
 
-        modalBottomSheet.show(supportFragmentManager, SimpleHouseListDialogFragment.TAG)
+//        modalBottomSheet.show(supportFragmentManager, SimpleHouseListDialogFragment.TAG)
+        SearchMapViewModel.BUILDING_TYPES =
+            resources.getStringArray(R.array.building_types).toList()
 
         initToolbar()
     }

--- a/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
@@ -26,7 +26,7 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
     private val minArea = MutableLiveData<Int>(13)
     private val maxArea = MutableLiveData<Int>(21)
     private val type = MutableLiveData<List<String>>(listOf("아파트"))
-    private val built = MutableLiveData<String>("전체")
+    private val built = MutableLiveData<Int>(0)
 
     fun getDistrictName() = districtName.value
 
@@ -48,7 +48,7 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
         }
 
     fun saveFilterSetting(
-        districtName: String, legalDongName: String, built: String,
+        districtName: String, legalDongName: String, built: Int,
         priceList: List<Float>, areaList: List<Float>, types: List<String>,
     ) {
         Log.d(
@@ -67,7 +67,7 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
     private fun loadFilteredData() {
         val districtName = districtName.value ?: return
         val legalDongName = legalDongName.value ?: return
-        val built = 0
+        val built = built.value ?: return
         val minArea = minArea.value ?: return
         val maxArea = maxArea.value ?: return
         val minPrice = minPrice.value ?: return

--- a/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
@@ -19,8 +19,8 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
     private val _buildings = MutableStateFlow<List<Building>>(listOf())
     val buildings = _buildings.asStateFlow()
 
-    private val districtName = MutableLiveData<String>("강남구")
-    private val legalDongName = MutableLiveData<String>("역삼1동")
+    private val districtName = MutableLiveData<String>(null)
+    private val legalDongName = MutableLiveData<String>(null)
     private val minPrice = MutableLiveData<Int>(MIN_PRICE)
     private val maxPrice = MutableLiveData<Int>(MAX_PRICE)
     private val minArea = MutableLiveData<Int>(MIN_AREA)
@@ -98,6 +98,6 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
         const val MIN_AREA = 3
         const val MAX_AREA = 60
         const val DEFAULT_BUILT = 1000
-        val BUILDING_TYPES = listOf("아파트", "오피스텔")
+        var BUILDING_TYPES = listOf<String>()
     }
 }

--- a/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
@@ -21,26 +21,32 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
 
     private val districtName = MutableLiveData<String>("강남구")
     private val legalDongName = MutableLiveData<String>("역삼1동")
-    private val minPrice = MutableLiveData<Int>(13)
-    private val maxPrice = MutableLiveData<Int>(17)
-    private val minArea = MutableLiveData<Int>(13)
-    private val maxArea = MutableLiveData<Int>(21)
-    private val type = MutableLiveData<List<String>>(listOf("아파트"))
-    private val built = MutableLiveData<Int>(0)
+    private val minPrice = MutableLiveData<Int>(MIN_PRICE)
+    private val maxPrice = MutableLiveData<Int>(MAX_PRICE)
+    private val minArea = MutableLiveData<Int>(MIN_AREA)
+    private val maxArea = MutableLiveData<Int>(MAX_AREA)
+    private val type = MutableLiveData<List<String>>(BUILDING_TYPES)
+    private val built = MutableLiveData<Int>(DEFAULT_BUILT)
 
     fun getDistrictName() = districtName.value
 
     fun getLegalDongName() = legalDongName.value
 
-    var priceList: List<Float> = listOf(0f, 0f)
-        get() = listOf(minPrice.value?.toFloat() ?: 0f, maxPrice.value?.toFloat() ?: 200f)
+    var priceList: List<Float> = listOf(MIN_PRICE, MAX_PRICE).map(Int::toFloat)
+        get() = listOf(
+            minPrice.value ?: MIN_PRICE,
+            maxPrice.value ?: MAX_PRICE
+        ).map(Int::toFloat)
         set(value) {
             minPrice.value = value[0].toInt()
             maxPrice.value = value[1].toInt()
             field = value
         }
-    var areaList = listOf(0f, 0f)
-        get() = listOf(minArea.value?.toFloat() ?: 0f, maxArea.value?.toFloat() ?: 100f)
+    var areaList = listOf(MIN_AREA, MAX_AREA).map(Int::toFloat)
+        get() = listOf(
+            minArea.value ?: MIN_AREA,
+            maxArea.value ?: MAX_AREA
+        ).map(Int::toFloat)
         set(value) {
             minArea.value = value[0].toInt()
             maxArea.value = value[1].toInt()
@@ -67,12 +73,12 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
     private fun loadFilteredData() {
         val districtName = districtName.value ?: return
         val legalDongName = legalDongName.value ?: return
-        val built = built.value ?: return
-        val minArea = minArea.value ?: return
-        val maxArea = maxArea.value ?: return
-        val minPrice = minPrice.value ?: return
-        val maxPrice = maxPrice.value ?: return
-        val type = type.value ?: return
+        val built = built.value ?: DEFAULT_BUILT
+        val minArea = minArea.value ?: MIN_AREA
+        val maxArea = maxArea.value ?: MAX_AREA
+        val minPrice = minPrice.value ?: MIN_AREA
+        val maxPrice = maxPrice.value ?: MAX_PRICE
+        val type = type.value ?: BUILDING_TYPES
         val searchFilter = SearchFilter(
             districtName, legalDongName, minPrice,
             maxPrice, minArea, maxArea,
@@ -84,5 +90,14 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
                 _buildings.value = it
             }
         }
+    }
+
+    companion object {
+        const val MIN_PRICE = 0
+        const val MAX_PRICE = 100
+        const val MIN_AREA = 3
+        const val MAX_AREA = 60
+        const val DEFAULT_BUILT = 1000
+        val BUILDING_TYPES = listOf("아파트", "오피스텔")
     }
 }

--- a/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterFragment.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterFragment.kt
@@ -47,10 +47,10 @@ class SearchFilterFragment : Fragment() {
             builtArray, "전체"
         )
         binding.rangeSliderAreaSearchFilter.initRangeSlider(
-            0f, 100f, 1f, searchFilterViewModel.areaList
-        ) // 단위 백만
+            0f, 60f, 3f, searchFilterViewModel.areaList
+        ) // 단위 평
         binding.rangeSliderPriceSearchFilter.initRangeSlider(
-            0f, 100f, 1f, searchFilterViewModel.priceList
+            0f, 100f, 3f, searchFilterViewModel.priceList
         ) // 단위 천만
     }
 
@@ -89,6 +89,7 @@ class SearchFilterFragment : Fragment() {
         val districtName = binding.autoTextViewAddress1SearchFilter.editableText.toString()
         val legalDongName = binding.autoTextViewAddress2SearchFilter.editableText.toString()
         val built = binding.autoTextViewBuiltSearchFilter.editableText.toString()
+            .takeWhile { it.isDigit() }.takeIf { it.isNotBlank() }?.toInt() ?: 1000
         val priceList = binding.rangeSliderPriceSearchFilter.values
         val areaList = binding.rangeSliderAreaSearchFilter.values
         val types = binding.btnGroupHouseTypeSearchFilter.checkedButtonIds

--- a/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterFragment.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterFragment.kt
@@ -30,7 +30,6 @@ class SearchFilterFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSearchFilterBinding.inflate(layoutInflater, container, false)
-
         return binding.root
     }
 
@@ -82,7 +81,7 @@ class SearchFilterFragment : Fragment() {
         values = initValue
         setLabelFormatter { value ->
             if (value >= to) {
-                "제한 없음"
+                context.getString(R.string.MAX_RANGE_BAR)
             } else if (unit == null) {
                 value.toInt().toString()
             } else {

--- a/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterFragment.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterFragment.kt
@@ -47,10 +47,16 @@ class SearchFilterFragment : Fragment() {
             builtArray, "전체"
         )
         binding.rangeSliderAreaSearchFilter.initRangeSlider(
-            0f, 60f, 3f, searchFilterViewModel.areaList
+            SearchMapViewModel.MIN_AREA.toFloat(),
+            SearchMapViewModel.MAX_AREA.toFloat(),
+            AREA_RANGE_SEPARATION,
+            searchFilterViewModel.areaList,
         ) // 단위 평
         binding.rangeSliderPriceSearchFilter.initRangeSlider(
-            0f, 100f, 3f, searchFilterViewModel.priceList
+            SearchMapViewModel.MIN_PRICE.toFloat(),
+            SearchMapViewModel.MAX_PRICE.toFloat(),
+            PRICE_RANGE_SEPARATION,
+            searchFilterViewModel.priceList,
         ) // 단위 천만
     }
 
@@ -130,5 +136,8 @@ class SearchFilterFragment : Fragment() {
         private val districtNames = arrayOf("강남구", "서초구", "중구")
         private val legalDongNames = arrayOf("역삼1동", "논현1동", "신사동")
         private val builtArray = arrayOf("전체", "5년전", "10년전", "15년전")
+
+        private const val PRICE_RANGE_SEPARATION = 3f
+        private const val AREA_RANGE_SEPARATION = 3f
     }
 }

--- a/app/src/main/res/layout/fragment_search_filter.xml
+++ b/app/src/main/res/layout/fragment_search_filter.xml
@@ -102,7 +102,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tv_price_searchFilter"
-        style="@style/TOTT.Text.H3"
+        style="@style/TextAppearance.Material3.HeadlineMedium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/price_searchFilter"
@@ -110,6 +110,16 @@
         app:layout_constraintStart_toStartOf="@id/guideline_start_vertical_searchFilter"
         app:layout_constraintTop_toBottomOf="@id/inputLayout_address1_searchFilter" />
 
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tv_price_unit_searchFilter"
+        android:layout_marginStart="10dp"
+        style="@style/TextAppearance.Material3.HeadlineSmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/price_unit_searchFilter"
+        app:layout_constraintStart_toEndOf="@id/tv_price_searchFilter"
+        app:layout_constraintBottom_toBottomOf="@id/tv_price_searchFilter" />
 
     <com.google.android.material.slider.RangeSlider
         android:id="@+id/rangeSlider_price_searchFilter"
@@ -130,6 +140,16 @@
         app:layout_constraintBottom_toTopOf="@id/rangeSlider_area_searchFilter"
         app:layout_constraintStart_toStartOf="@id/guideline_start_vertical_searchFilter"
         app:layout_constraintTop_toBottomOf="@id/rangeSlider_price_searchFilter" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tv_area_unit_searchFilter"
+        android:layout_marginStart="10dp"
+        style="@style/TextAppearance.Material3.HeadlineSmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/price_area_searchFilter"
+        app:layout_constraintStart_toEndOf="@id/tv_area_searchFilter"
+        app:layout_constraintBottom_toBottomOf="@id/tv_area_searchFilter" />
 
     <com.google.android.material.slider.RangeSlider
         android:id="@+id/rangeSlider_area_searchFilter"

--- a/app/src/main/res/layout/fragment_search_filter.xml
+++ b/app/src/main/res/layout/fragment_search_filter.xml
@@ -50,7 +50,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tv_address_searchFilter"
-        style="@style/TOTT.Text.H3"
+        style="@style/TextAppearance.Material3.HeadlineMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
@@ -61,7 +61,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/inputLayout_address1_searchFilter"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="30dp"
@@ -72,6 +72,7 @@
 
         <com.google.android.material.textfield.MaterialAutoCompleteTextView
             android:id="@+id/autoTextView_address1_searchFilter"
+            style="@style/TextAppearance.Material3.BodyLarge"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="none"
@@ -84,7 +85,6 @@
         style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-
         app:layout_constraintBottom_toBottomOf="@+id/inputLayout_address1_searchFilter"
         app:layout_constraintEnd_toEndOf="@id/guideline_end_vertical_searchFilter"
         app:layout_constraintStart_toEndOf="@id/inputLayout_address1_searchFilter"
@@ -92,8 +92,8 @@
 
         <com.google.android.material.textfield.MaterialAutoCompleteTextView
             android:id="@+id/autoTextView_address2_searchFilter"
+            style="@style/TextAppearance.Material3.BodyLarge"
             android:layout_width="match_parent"
-
             android:layout_height="wrap_content"
             android:inputType="none"
             tools:text="역삼1동" />
@@ -113,13 +113,13 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tv_price_unit_searchFilter"
-        android:layout_marginStart="10dp"
-        style="@style/TextAppearance.Material3.HeadlineSmall"
+        style="@style/TextAppearance.Material3.TitleMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
         android:text="@string/price_unit_searchFilter"
-        app:layout_constraintStart_toEndOf="@id/tv_price_searchFilter"
-        app:layout_constraintBottom_toBottomOf="@id/tv_price_searchFilter" />
+        app:layout_constraintBottom_toBottomOf="@id/tv_price_searchFilter"
+        app:layout_constraintStart_toEndOf="@id/tv_price_searchFilter" />
 
     <com.google.android.material.slider.RangeSlider
         android:id="@+id/rangeSlider_price_searchFilter"
@@ -133,7 +133,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tv_area_searchFilter"
-        style="@style/TOTT.Text.H3"
+        style="@style/TextAppearance.Material3.HeadlineMedium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/area_searchFilter"
@@ -143,13 +143,13 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tv_area_unit_searchFilter"
-        android:layout_marginStart="10dp"
-        style="@style/TextAppearance.Material3.HeadlineSmall"
+        style="@style/TextAppearance.Material3.TitleMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
         android:text="@string/price_area_searchFilter"
-        app:layout_constraintStart_toEndOf="@id/tv_area_searchFilter"
-        app:layout_constraintBottom_toBottomOf="@id/tv_area_searchFilter" />
+        app:layout_constraintBottom_toBottomOf="@id/tv_area_searchFilter"
+        app:layout_constraintStart_toEndOf="@id/tv_area_searchFilter" />
 
     <com.google.android.material.slider.RangeSlider
         android:id="@+id/rangeSlider_area_searchFilter"
@@ -162,7 +162,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tv_houseType_searchFilter"
-        style="@style/TOTT.Text.H3"
+        style="@style/TextAppearance.Material3.HeadlineMedium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/houseType_searchFilter"
@@ -199,7 +199,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tv_built_searchFilter"
-        style="@style/TOTT.Text.H3"
+        style="@style/TextAppearance.Material3.HeadlineMedium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/built_searchFilter"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="built_searchFilter">준공년도</string>
     <string name="houseType_searchFilter">종류</string>
     <string name="toolbar_saveFilter">저장</string>
+    <string name="price_unit_searchFilter">단위: 천만원</string>
+    <string name="price_area_searchFilter">단위: 평</string>
 
     <!--  매물 화면  -->
     <string name="toolbar_buildingDetail_item">상세 정보</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="toolbar_saveFilter">저장</string>
     <string name="price_unit_searchFilter">단위: 천만원</string>
     <string name="price_area_searchFilter">단위: 평</string>
+    <string name="MAX_RANGE_BAR">제한 없음</string>
 
     <!--  매물 화면  -->
     <string name="toolbar_buildingDetail_item">상세 정보</string>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -11,6 +11,7 @@
 
     <style name="TOTT.OutlinedButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:textColor">@color/font</item>
+        <item name="android:textAppearance">@style/TextAppearance.Material3.BodyLarge</item>
     </style>
 
     <style name="TOTT.FilledButton" parent="Widget.Material3.Button.TextButton">

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -8,4 +8,8 @@
         <item>20.0</item>
         <item>30.0</item>
     </array>
+    <string-array name = "building_types">
+        <item>아파트</item>
+        <item>오피스텔</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
# 개요

- 필터의 기본값, 최댓값, 최솟값 변경
- 화면의 각 컴포넌트 스타일 변경

resolve #23 

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
<!-- example ) -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 한 일

- 필터의 기본값, 최댓값, 최솟값 변경
  - 건축 연도는 전체 범위 1000, 나머지는 5, 10, 15, 20, 25로 전달
    - 모두 정수 형태
  - 면적 슬라이더 최대 범위를 60으로 조정
- 전세 가격, 면적 옆에 단위 설명 추가
- 화면의 각 컴포넌트 스타일 변경
  - 글자, 드롭 다운 메뉴에 material style 적용

<!-- 한 일 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

## ETC

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->