### PR TITLE
필터 화면에 지역 이름과 코드를 가져오는 기능 추가

### DIFF
--- a/app/src/main/java/com/ssafy/tott/data/datasource/remote/RegionRemoteDataSource.kt
+++ b/app/src/main/java/com/ssafy/tott/data/datasource/remote/RegionRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package com.ssafy.tott.data.datasource.remote
+
+import com.ssafy.tott.data.model.response.RegionPairResponse
+import kotlinx.coroutines.flow.Flow
+
+interface RegionRemoteDataSource {
+    fun getDistrictPairList(): Flow<Result<List<RegionPairResponse>>>
+    fun getLegalDongPairList(districtCode: Int): Flow<Result<List<RegionPairResponse>>>
+}

--- a/app/src/main/java/com/ssafy/tott/data/datasource/remote/RegionRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/tott/data/datasource/remote/RegionRemoteDataSourceImpl.kt
@@ -12,7 +12,9 @@ class RegionRemoteDataSourceImpl @Inject constructor(private val regionService: 
     override fun getDistrictPairList() = flow<Result<List<RegionPairResponse>>> {
         val response = regionService.fetchGetDistrictList()
         if (response.isSuccessful) {
-            val data = response.body()?.get("districtList") ?: emptyList()
+            Log.d("RegionRemoteDataSourceImpl", "getDistrictPairList: body ${response.body()}")
+            val data = response.body()?.list ?: emptyList()
+            Log.d("RegionRemoteDataSourceImpl", "getDistrictPairList: body ${data}")
             emit(Result.success(data))
         } else {
             val errorResponse = getErrorResponse(response.errorBody()?.string() ?: "")
@@ -24,7 +26,7 @@ class RegionRemoteDataSourceImpl @Inject constructor(private val regionService: 
     override fun getLegalDongPairList(districtCode: Int) = flow<Result<List<RegionPairResponse>>> {
         val response = regionService.fetchGetLegalDongList(districtCode)
         if (response.isSuccessful) {
-            val data = response.body()?.get("legalDongList") ?: emptyList()
+            val data = response.body()?.list ?: emptyList()
             emit(Result.success(data))
         } else {
             val errorResponse = getErrorResponse(response.errorBody()?.string() ?: "")

--- a/app/src/main/java/com/ssafy/tott/data/datasource/remote/RegionRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/tott/data/datasource/remote/RegionRemoteDataSourceImpl.kt
@@ -1,0 +1,35 @@
+package com.ssafy.tott.data.datasource.remote
+
+import android.util.Log
+import com.ssafy.tott.data.datasource.remote.service.RegionService
+import com.ssafy.tott.data.mapper.getErrorResponse
+import com.ssafy.tott.data.model.response.RegionPairResponse
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RegionRemoteDataSourceImpl @Inject constructor(private val regionService: RegionService) :
+    RegionRemoteDataSource {
+    override fun getDistrictPairList() = flow<Result<List<RegionPairResponse>>> {
+        val response = regionService.fetchGetDistrictList()
+        if (response.isSuccessful) {
+            val data = response.body()?.get("districtList") ?: emptyList()
+            emit(Result.success(data))
+        } else {
+            val errorResponse = getErrorResponse(response.errorBody()?.string() ?: "")
+            Log.d("BuildingDataSourceRemote", "login: $errorResponse}")
+            emit(Result.failure(errorResponse.toNetworkException()))
+        }
+    }
+
+    override fun getLegalDongPairList(districtCode: Int) = flow<Result<List<RegionPairResponse>>> {
+        val response = regionService.fetchGetLegalDongList(districtCode)
+        if (response.isSuccessful) {
+            val data = response.body()?.get("legalDongList") ?: emptyList()
+            emit(Result.success(data))
+        } else {
+            val errorResponse = getErrorResponse(response.errorBody()?.string() ?: "")
+            Log.d("BuildingDataSourceRemote", "login: $errorResponse}")
+            emit(Result.failure(errorResponse.toNetworkException()))
+        }
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/data/datasource/remote/service/RegionService.kt
+++ b/app/src/main/java/com/ssafy/tott/data/datasource/remote/service/RegionService.kt
@@ -1,0 +1,18 @@
+package com.ssafy.tott.data.datasource.remote.service
+
+import com.ssafy.tott.data.model.response.RegionPairResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface RegionService {
+    @POST("/api/region/auth/find/district")
+    suspend fun fetchGetDistrictList(): Response<Map<String, List<RegionPairResponse>>>
+
+    @GET("/api/region/auth/find/legal")
+    suspend fun fetchGetLegalDongList(
+        @Query("districtCode")
+        code: Int
+    ): Response<Map<String, List<RegionPairResponse>>>
+}

--- a/app/src/main/java/com/ssafy/tott/data/datasource/remote/service/RegionService.kt
+++ b/app/src/main/java/com/ssafy/tott/data/datasource/remote/service/RegionService.kt
@@ -1,18 +1,18 @@
 package com.ssafy.tott.data.datasource.remote.service
 
-import com.ssafy.tott.data.model.response.RegionPairResponse
+import com.ssafy.tott.data.model.response.DistrictListResponse
+import com.ssafy.tott.data.model.response.LegalDongListResponse
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface RegionService {
-    @POST("/api/region/auth/find/district")
-    suspend fun fetchGetDistrictList(): Response<Map<String, List<RegionPairResponse>>>
+    @GET("/api/region/auth/find/district")
+    suspend fun fetchGetDistrictList(): Response<DistrictListResponse>
 
     @GET("/api/region/auth/find/legal")
     suspend fun fetchGetLegalDongList(
         @Query("districtCode")
         code: Int
-    ): Response<Map<String, List<RegionPairResponse>>>
+    ): Response<LegalDongListResponse>
 }

--- a/app/src/main/java/com/ssafy/tott/data/model/response/DistrictListResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/DistrictListResponse.kt
@@ -1,0 +1,8 @@
+package com.ssafy.tott.data.model.response
+
+import com.google.gson.annotations.SerializedName
+
+data class DistrictListResponse(
+    @SerializedName("districtList")
+    val list: List<RegionPairResponse>,
+)

--- a/app/src/main/java/com/ssafy/tott/data/model/response/LegalDongListResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/LegalDongListResponse.kt
@@ -1,0 +1,8 @@
+package com.ssafy.tott.data.model.response
+
+import com.google.gson.annotations.SerializedName
+
+data class LegalDongListResponse(
+    @SerializedName("legalDongList")
+    val list: List<RegionPairResponse>,
+)

--- a/app/src/main/java/com/ssafy/tott/data/model/response/RegionPairResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/RegionPairResponse.kt
@@ -1,10 +1,18 @@
 package com.ssafy.tott.data.model.response
 
 import com.google.gson.annotations.SerializedName
+import com.ssafy.tott.domain.model.RegionPair
 
 data class RegionPairResponse(
     @SerializedName("name")
     val name: String,
     @SerializedName("code")
-    val code: String,
-)
+    val code: Int,
+) {
+    companion object {
+        fun RegionPairResponse.toDomain() = RegionPair(
+            name = name,
+            code = code,
+        )
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/data/model/response/RegionPairResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/RegionPairResponse.kt
@@ -1,0 +1,10 @@
+package com.ssafy.tott.data.model.response
+
+import com.google.gson.annotations.SerializedName
+
+data class RegionPairResponse(
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("code")
+    val code: String,
+)

--- a/app/src/main/java/com/ssafy/tott/data/model/response/RegionPairResponse.kt
+++ b/app/src/main/java/com/ssafy/tott/data/model/response/RegionPairResponse.kt
@@ -9,10 +9,8 @@ data class RegionPairResponse(
     @SerializedName("code")
     val code: Int,
 ) {
-    companion object {
-        fun RegionPairResponse.toDomain() = RegionPair(
-            name = name,
-            code = code,
-        )
-    }
+    fun toDomain() = RegionPair(
+        name = name,
+        code = code,
+    )
 }

--- a/app/src/main/java/com/ssafy/tott/data/repository/RegionRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/tott/data/repository/RegionRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.ssafy.tott.data.repository
+
+import com.ssafy.tott.data.datasource.remote.RegionRemoteDataSource
+import com.ssafy.tott.domain.model.RegionPair
+import com.ssafy.tott.domain.repository.RegionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class RegionRepositoryImpl @Inject constructor(
+    private val regionRemoteDataSource: RegionRemoteDataSource,
+) : RegionRepository {
+    override fun getDistrictPairList(): Flow<Result<List<RegionPair>>> {
+        return regionRemoteDataSource.getDistrictPairList().map { result ->
+            result.map { list -> list.map { it.toDomain() } }
+        }
+    }
+
+    override fun getLegalDongPairList(districtCode: Int): Flow<Result<List<RegionPair>>> {
+        return regionRemoteDataSource.getLegalDongPairList(districtCode).map { result ->
+            result.map { list -> list.map { it.toDomain() } }
+        }
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/di/DataModule.kt
+++ b/app/src/main/java/com/ssafy/tott/di/DataModule.kt
@@ -6,8 +6,11 @@ import com.ssafy.tott.data.datasource.local.DataStoreManager
 import com.ssafy.tott.data.datasource.local.UserTokenDataSource
 import com.ssafy.tott.data.datasource.local.UserTokenDataSourceImpl
 import com.ssafy.tott.data.datasource.remote.BuildingRemoteDataSource
+import com.ssafy.tott.data.datasource.remote.RegionRemoteDataSource
+import com.ssafy.tott.data.datasource.remote.RegionRemoteDataSourceImpl
 import com.ssafy.tott.data.datasource.remote.UserDataSourceRemote
 import com.ssafy.tott.data.datasource.remote.service.BuildingService
+import com.ssafy.tott.data.datasource.remote.service.RegionService
 import com.ssafy.tott.data.datasource.remote.service.UserService
 import com.ssafy.tott.data.repository.BuildingRepositoryImpl
 import com.ssafy.tott.data.repository.UserRepositoryImpl
@@ -49,4 +52,10 @@ object DataModule {
     @Singleton
     fun provideUserTokenDataSource(dataStoreManager: DataStoreManager): UserTokenDataSource =
         UserTokenDataSourceImpl(dataStoreManager)
+
+
+    @Provides
+    @Singleton
+    fun provideRegionDataSource(regionService: RegionService): RegionRemoteDataSource =
+        RegionRemoteDataSourceImpl(regionService)
 }

--- a/app/src/main/java/com/ssafy/tott/di/DataModule.kt
+++ b/app/src/main/java/com/ssafy/tott/di/DataModule.kt
@@ -13,8 +13,10 @@ import com.ssafy.tott.data.datasource.remote.service.BuildingService
 import com.ssafy.tott.data.datasource.remote.service.RegionService
 import com.ssafy.tott.data.datasource.remote.service.UserService
 import com.ssafy.tott.data.repository.BuildingRepositoryImpl
+import com.ssafy.tott.data.repository.RegionRepositoryImpl
 import com.ssafy.tott.data.repository.UserRepositoryImpl
 import com.ssafy.tott.domain.repository.BuildingRepository
+import com.ssafy.tott.domain.repository.RegionRepository
 import com.ssafy.tott.domain.repository.UserRepository
 import dagger.Module
 import dagger.Provides
@@ -58,4 +60,10 @@ object DataModule {
     @Singleton
     fun provideRegionDataSource(regionService: RegionService): RegionRemoteDataSource =
         RegionRemoteDataSourceImpl(regionService)
+
+
+    @Provides
+    @Singleton
+    fun provideRegionRepository(regionDataSource: RegionRemoteDataSource): RegionRepository =
+        RegionRepositoryImpl(regionDataSource)
 }

--- a/app/src/main/java/com/ssafy/tott/di/NetworkModule.kt
+++ b/app/src/main/java/com/ssafy/tott/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.google.maps.android.v3.ktx.BuildConfig
 import com.ssafy.tott.data.datasource.local.DataStoreManager
 import com.ssafy.tott.data.datasource.remote.service.BuildingService
+import com.ssafy.tott.data.datasource.remote.service.RegionService
 import com.ssafy.tott.data.datasource.remote.service.UserService
 import com.ssafy.tott.data.model.response.AuthTokenRemoteResponse
 import com.ssafy.tott.domain.exception.NetworkException
@@ -100,6 +101,12 @@ object NetworkModule {
     @Singleton
     fun provideUserApiService(@OtherRetrofit retrofit: Retrofit): UserService {
         return retrofit.create(UserService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRegionApiService(@AuthRetrofit retrofit: Retrofit): RegionService {
+        return retrofit.create(RegionService::class.java)
     }
 
     @Singleton

--- a/app/src/main/java/com/ssafy/tott/domain/model/RegionPair.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/model/RegionPair.kt
@@ -1,0 +1,6 @@
+package com.ssafy.tott.domain.model
+
+data class RegionPair(
+    val name: String,
+    val code: Int,
+)

--- a/app/src/main/java/com/ssafy/tott/domain/repository/RegionRepository.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/repository/RegionRepository.kt
@@ -1,0 +1,9 @@
+package com.ssafy.tott.domain.repository
+
+import com.ssafy.tott.domain.model.RegionPair
+import kotlinx.coroutines.flow.Flow
+
+interface RegionRepository {
+    fun getDistrictPairList(): Flow<Result<List<RegionPair>>>
+    fun getLegalDongPairList(districtCode: Int): Flow<Result<List<RegionPair>>>
+}

--- a/app/src/main/java/com/ssafy/tott/domain/usecase/GetDistrictListUseCase.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/usecase/GetDistrictListUseCase.kt
@@ -1,0 +1,20 @@
+package com.ssafy.tott.domain.usecase
+
+import com.ssafy.tott.domain.repository.RegionRepository
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class GetDistrictListUseCase @Inject constructor(
+    private val regionRepository: RegionRepository,
+) {
+    operator fun invoke() = flow<Result<Map<String, Int>>> {
+        regionRepository.getDistrictPairList().collect { result ->
+            result.onSuccess { districtList ->
+                val map = districtList.associate { district -> district.name to district.code }
+                emit(Result.success(map))
+            }.onFailure {
+                emit(Result.failure(it))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/domain/usecase/GetLegalDongListUseCase.kt
+++ b/app/src/main/java/com/ssafy/tott/domain/usecase/GetLegalDongListUseCase.kt
@@ -1,0 +1,19 @@
+package com.ssafy.tott.domain.usecase
+
+import com.ssafy.tott.domain.repository.RegionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class GetLegalDongListUseCase @Inject constructor(private val regionRepository: RegionRepository) {
+    operator fun invoke(districtCode: Int): Flow<Result<Map<String, Int>>> = flow {
+        regionRepository.getLegalDongPairList(districtCode).collect { dongResult ->
+            dongResult.onSuccess { dongList ->
+                val map = dongList.associate { dong -> dong.name to dong.code }
+                emit(Result.success(map))
+            }.onFailure {
+                emit(Result.failure(it))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/map/SearchMapViewModel.kt
@@ -21,25 +21,14 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
     private val _buildings = MutableStateFlow<List<Building>>(listOf())
     val buildings = _buildings.asStateFlow()
 
-    private val _region = MutableLiveData<Region>()
-    val region: LiveData<Region> = _region
-
-    init {
-        _region.value = Region("강남구", 11680, mapOf("역삼1동" to 10100))
-    }
-
-    private val districtName = MutableLiveData<String>(null)
-    private val legalDongName = MutableLiveData<String>(null)
+    private val districtCode = MutableLiveData<Int>(null)
+    private val legalDongCode = MutableLiveData<Int>(null)
     private val minPrice = MutableLiveData<Int>(MIN_PRICE)
     private val maxPrice = MutableLiveData<Int>(MAX_PRICE)
     private val minArea = MutableLiveData<Int>(MIN_AREA)
     private val maxArea = MutableLiveData<Int>(MAX_AREA)
     private val type = MutableLiveData<List<String>>(BUILDING_TYPES)
     private val built = MutableLiveData<Int>(DEFAULT_BUILT)
-
-    fun getDistrictName() = districtName.value
-
-    fun getLegalDongName() = legalDongName.value
 
     var priceList: List<Float> = listOf(MIN_PRICE, MAX_PRICE).map(Int::toFloat)
         get() = listOf(
@@ -63,15 +52,16 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
         }
 
     fun saveFilterSetting(
-        districtName: String, legalDongName: String, built: Int,
+        districtCode: Int, legalDongCode: Int, built: Int,
         priceList: List<Float>, areaList: List<Float>, types: List<String>,
     ) {
         Log.d(
-            this::class.java.simpleName, "loadData: $districtName $legalDongName $built" +
+            this::class.java.simpleName,
+            "loadData: ${this.districtCode} ${this.legalDongCode} $built" +
                     "$priceList $areaList $types"
         )
-        this.districtName.value = districtName
-        this.legalDongName.value = legalDongName
+        this.districtCode.value = districtCode
+        this.legalDongCode.value = legalDongCode
         this.built.value = built
         this.priceList = priceList
         this.areaList = areaList
@@ -80,10 +70,8 @@ class SearchMapViewModel @Inject constructor(val useCase: SearchBuildingUseCase)
     }
 
     private fun loadFilteredData() {
-        val region = region.value
-        val districtCode = region?.code ?: 0
-        val legalDongName = legalDongName.value ?: ""
-        val legalDongCode = region?.legalDong?.get(legalDongName) ?: 0
+        val districtCode = districtCode.value ?: 0
+        val legalDongCode = legalDongCode.value ?: 0
         val built = built.value ?: DEFAULT_BUILT
         val minArea = minArea.value ?: MIN_AREA
         val maxArea = maxArea.value ?: MAX_AREA

--- a/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterFragment.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterFragment.kt
@@ -8,27 +8,34 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AutoCompleteTextView
 import android.widget.Button
+import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.slider.RangeSlider
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.ssafy.tott.R
 import com.ssafy.tott.databinding.FragmentSearchFilterBinding
 import com.ssafy.tott.ui.map.SearchMapActivity
 import com.ssafy.tott.ui.map.SearchMapViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class SearchFilterFragment : Fragment() {
-    private val searchFilterViewModel: SearchMapViewModel by activityViewModels()
+    private val searchMapViewModel: SearchMapViewModel by activityViewModels()
+    private val searchFilterViewModel: SearchFilterViewModel by viewModels()
     private var _binding: FragmentSearchFilterBinding? = null
     private val binding get() = _binding!!
     private val callback: OnBackPressedCallback by lazyOf(initOnBackPressedCallback())
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSearchFilterBinding.inflate(layoutInflater, container, false)
         return binding.root
@@ -36,36 +43,69 @@ class SearchFilterFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        binding.autoTextViewAddress1SearchFilter.initAutoTextView(
-            districtNames, searchFilterViewModel.getDistrictName() ?: "선택"
-        )
-        binding.autoTextViewAddress2SearchFilter.initAutoTextView(
-            legalDongNames, searchFilterViewModel.getLegalDongName() ?: "선택"
-        )
-        binding.autoTextViewBuiltSearchFilter.initAutoTextView(
+        binding.autoTextViewBuiltSearchFilter.setAutoTextView(
             builtArray, "전체"
         )
         binding.rangeSliderAreaSearchFilter.initRangeSlider(
             SearchMapViewModel.MIN_AREA.toFloat(),
             SearchMapViewModel.MAX_AREA.toFloat(),
             AREA_RANGE_SEPARATION,
-            searchFilterViewModel.areaList,
+            searchMapViewModel.areaList,
         ) // 단위 평
         binding.rangeSliderPriceSearchFilter.initRangeSlider(
             SearchMapViewModel.MIN_PRICE.toFloat(),
             SearchMapViewModel.MAX_PRICE.toFloat(),
             PRICE_RANGE_SEPARATION,
-            searchFilterViewModel.priceList,
+            searchMapViewModel.priceList,
         ) // 단위 천만
+        initObserve()
     }
 
-    private fun AutoCompleteTextView.initAutoTextView(array: Array<String>, value: String) {
+    private fun initObserve() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            searchFilterViewModel.districtMap.observe(
+                viewLifecycleOwner
+            ) {
+                val array = it.keys.toTypedArray()
+                binding.autoTextViewAddress1SearchFilter.setAutoTextView(
+                    array, array.firstOrNull() ?: "선택"
+                ) { searchFilterViewModel.selectDistrict(it) }
+            }
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            searchFilterViewModel.uiError.flowWithLifecycle(
+                viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED
+            ).collect {
+                if (it != null) {
+                    Snackbar.make(binding.root, it.message ?: "오류 발생", Snackbar.LENGTH_LONG).show()
+                }
+            }
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            searchFilterViewModel.legalDongMap.observe(
+                viewLifecycleOwner
+            ) {
+                Log.d("SearchFilterFragment", "observe legalDongMap: $it")
+                val array = it.keys.toTypedArray()
+                binding.autoTextViewAddress2SearchFilter.setAutoTextView(
+                    array, array.firstOrNull() ?: "선택"
+                )
+            }
+        }
+    }
+
+    private fun AutoCompleteTextView.setAutoTextView(
+        array: Array<String>,
+        value: String,
+        listener: ((str: String?) -> Unit)? = null,
+    ) {
         setText(value)
         val textView = this as? MaterialAutoCompleteTextView ?: return
         textView.setSimpleItems(array)
         textView.setOnItemClickListener { adapterView, view, i, l ->
-            //TODO 아이템 선택 리스너 구현
+            if (listener != null) {
+                listener((view as? TextView)?.text.toString())
+            }
         }
     }
 
@@ -94,15 +134,18 @@ class SearchFilterFragment : Fragment() {
     fun savedFilterSetting() {
         val districtName = binding.autoTextViewAddress1SearchFilter.editableText.toString()
         val legalDongName = binding.autoTextViewAddress2SearchFilter.editableText.toString()
-        val built = binding.autoTextViewBuiltSearchFilter.editableText.toString()
-            .takeWhile { it.isDigit() }.takeIf { it.isNotBlank() }?.toInt() ?: 1000
+        val districtCode = searchFilterViewModel.districtMap.value?.get(districtName) ?: -1
+        val legalDongCode = searchFilterViewModel.legalDongMap.value?.get(legalDongName) ?: -1
+        val built =
+            binding.autoTextViewBuiltSearchFilter.editableText.toString().takeWhile { it.isDigit() }
+                .takeIf { it.isNotBlank() }?.toInt() ?: 1000
         val priceList = binding.rangeSliderPriceSearchFilter.values
         val areaList = binding.rangeSliderAreaSearchFilter.values
         val typeIds = binding.btnGroupHouseTypeSearchFilter.checkedButtonIds
-        val types = typeIds.filter { it != View.NO_ID }.map { binding.root.findViewById<Button>(it).text.toString() }
-        searchFilterViewModel.saveFilterSetting(
-            districtName, legalDongName, built,
-            priceList, areaList, types
+        val types = typeIds.filter { it != View.NO_ID }
+            .map { binding.root.findViewById<Button>(it).text.toString() }
+        searchMapViewModel.saveFilterSetting(
+            districtCode, legalDongCode, built, priceList, areaList, types
         )
         requireActivity().onBackPressed()
     }
@@ -133,9 +176,6 @@ class SearchFilterFragment : Fragment() {
     }
 
     companion object {
-        //TODO 드롭다운 임시 데이터
-        private val districtNames = arrayOf("강남구", "서초구", "중구")
-        private val legalDongNames = arrayOf("역삼1동", "논현1동", "신사동")
         private val builtArray = arrayOf("전체", "5년전", "10년전", "15년전")
 
         private const val PRICE_RANGE_SEPARATION = 3f

--- a/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterViewModel.kt
+++ b/app/src/main/java/com/ssafy/tott/ui/searchfilter/SearchFilterViewModel.kt
@@ -1,0 +1,65 @@
+package com.ssafy.tott.ui.searchfilter
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ssafy.tott.domain.usecase.GetDistrictListUseCase
+import com.ssafy.tott.domain.usecase.GetLegalDongListUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchFilterViewModel @Inject constructor(
+    private val getDistrictUseCase: GetDistrictListUseCase,
+    private val getLegalDongUseCase: GetLegalDongListUseCase,
+
+    ) : ViewModel() {
+    private val _districtMap = MutableStateFlow<Map<String, Int>>(mapOf())
+    val districtMap = _districtMap.asStateFlow()
+
+    private val _legalDongMap = MutableStateFlow<Map<String, Int>>(mapOf())
+    val legalDongMap = _districtMap.asStateFlow()
+
+    private val _uiError = MutableStateFlow<Throwable?>(null)
+    val uiError = _uiError.asStateFlow()
+
+    init {
+        loadDistrict()
+    }
+
+    private fun loadDistrict() {
+        viewModelScope.launch {
+            getDistrictUseCase().collect { districtResult ->
+                districtResult.onSuccess {
+                    _districtMap.value = it
+                    val firstDistrictCode = it.values.firstOrNull()
+                    if (firstDistrictCode == null) {
+                        _uiError.value = Exception("데이터가 없습니다.")
+                    } else {
+                        loadLegalDongMap(firstDistrictCode)
+                    }
+                }.onFailure {
+                    _uiError.value = it
+                }
+            }
+        }
+    }
+
+    fun loadLegalDongMap(districtCode: Int) {
+        viewModelScope.launch {
+            getLegalDongUseCase(districtCode).collect { dongResult ->
+                dongResult.onSuccess { map ->
+                    if (map.isEmpty()) {
+                        _legalDongMap.value = map
+                    } else {
+                        _uiError.value = Exception("데이터가 없습니다.")
+                    }
+                }.onFailure {
+                    _uiError.value = it
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 개요

- 지역 이름과 코드를 가져오는 기능 추가
  - 지역구, 법정동

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
<!-- example ) -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 한 일

- 지역 이름과 코드를 가져오는 기능 추가
- 지역 코드로 검색하는 기능 추가

<!-- 한 일 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

## ETC

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->